### PR TITLE
Update dependencies, fix deprecation issues, fix tab 2 export

### DIFF
--- a/core/dataClass.py
+++ b/core/dataClass.py
@@ -278,7 +278,7 @@ class Data:
 
         # iterate over all columns of current sheet in dataset
         names_list = []
-        for (column_name, column_data) in self.dataSet[self.sheetNames[self._currentSheet]].iteritems():
+        for (column_name, column_data) in self.dataSet[self.sheetNames[self._currentSheet]].items():
             if column_name not in self.STATIC_NAMES:
                 names_list.append(column_name)  # column assumed to be covariate data
         self.metricNames = names_list
@@ -348,7 +348,7 @@ class PandasModel(QtCore.QAbstractTableModel):
         return False
 
     def roundCell(self, value):
-        if isinstance(value, np.float):
+        if isinstance(value, float):
             return str(round(value, ndigits=6))
         else:
             return str(value)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-numpy==1.22.0
-openpyxl==3.0.6
-pandas==1.1.5
-PyQt5==5.15.2
-pyqtgraph==0.11.1
-scipy==1.5.4
-symengine==0.6.1
-sympy==1.7.1
+numpy==1.25.2
+openpyxl==3.1.2
+pandas==2.0.3
+PyQt5==5.15.9
+pyqtgraph==0.13.3
+scipy==1.11.1
+symengine==0.10.0
+sympy==1.12

--- a/ui/tab2.py
+++ b/ui/tab2.py
@@ -131,6 +131,8 @@ class Tab2(QWidget):
         self.dataframeMVF.columns = column_names
         self.modelMVF.setAllData(self.dataframeMVF)
 
+        self.tableModel = PandasModel(self.dataframeMVF)
+
         temp_df = pd.DataFrame(intensity_list)
         self.dataframeIntensity = temp_df.transpose()
         self.dataframeIntensity.columns = column_names


### PR DESCRIPTION
Some issues found when installing python requirements, prerequisites would fail on install when installing older, deprecated libraries. Using upgraded versions worked with minor changes due to method deprecations so some tweaks were added to fix. In testing, exporting the tab 2 table caused an exception as the table dataframe was never defined, so it is now updated to the MVF dataframe when models are updated a la tab 3's way.